### PR TITLE
feat: deploy proposal-sync from the published dc-charts oci package

### DIFF
--- a/.github/workflows/proposal-sync.yml
+++ b/.github/workflows/proposal-sync.yml
@@ -51,7 +51,8 @@ jobs:
       namespace_prefix: scilog-
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
-      helm_chart: helm/charts/cron_chart
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/cron
+      helm_chart_version: 1.0.0
       commit: ${{ needs.set_env.outputs.commit }}
       submodule_commit: ${{ github.event.inputs.submodule_commit }}
       submodule: scilog

--- a/helm/configs/proposal-sync/values.yaml
+++ b/helm/configs/proposal-sync/values.yaml
@@ -39,3 +39,7 @@ initContainers:
     volumeMounts:
       - name: downloaddir
         mountPath: "/download-dir"
+
+# Keep the pre-rename chart name so resource names stay stable for the
+# release installed from the vendored cron-chart.
+nameOverride: cron-chart


### PR DESCRIPTION
Switches proposal-sync to the published dc-charts oci cron chart. nameOverride: cron-chart keeps CronJob names stable across the rename.