### PR TITLE
feat: deploy backend from the published dc-charts oci package

### DIFF
--- a/.github/workflows/be.yml
+++ b/.github/workflows/be.yml
@@ -49,6 +49,8 @@ jobs:
       namespace_prefix: scilog-
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       commit: ${{ needs.set_env.outputs.commit }}
       submodule_commit: ${{ github.event.inputs.submodule_commit }}
       submodule: scilog

--- a/helm/configs/backend/values.yaml
+++ b/helm/configs/backend/values.yaml
@@ -90,3 +90,7 @@ probeChecks:
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 5
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Switches backend to the published dc-charts oci generic-service chart. nameOverride: generic-service-chart keeps the Deployment selector stable (immutable field) across the rename.