### PR TITLE
feat: deploy frontend from the published dc-charts oci package

### DIFF
--- a/.github/workflows/fe.yml
+++ b/.github/workflows/fe.yml
@@ -50,6 +50,8 @@ jobs:
       namespace_prefix: scilog-
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       commit: ${{ needs.set_env.outputs.commit }}
       submodule_commit: ${{ github.event.inputs.submodule_commit }}
       submodule: scilog

--- a/helm/configs/frontend/values.yaml
+++ b/helm/configs/frontend/values.yaml
@@ -38,3 +38,7 @@ volumeMounts:
   - name: config-volume
     mountPath: /usr/share/nginx/html/assets/config.json
     subPath: config.json
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Switches frontend to the published dc-charts oci generic-service chart. nameOverride: generic-service-chart keeps the Deployment selector stable (immutable field) across the rename.